### PR TITLE
fix(op-check): replace command with which

### DIFF
--- a/lua/1password/init.lua
+++ b/lua/1password/init.lua
@@ -64,8 +64,8 @@ local function check_op_cli(callback)
   -- First check if the CLI is installed
   Job
     :new({
-      command = 'command',
-      args = { '-v', 'op' },
+      command = 'which',
+      args = { 'op' },
       on_exit = function(_, return_val)
         if return_val ~= 0 then
           callback(false, '1Password CLI (op) not found in PATH')

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,4 @@
+std="vim"
+
+[lints]
+mixed_table="allow"


### PR DESCRIPTION
Closes #1 

Replace the `command` program with `which` for checking if op is executable.